### PR TITLE
Add one Annotation @Vetrex for domain class.

### DIFF
--- a/src/main/java/com/microsoft/spring/data/gremlin/annotation/Vertex.java
+++ b/src/main/java/com/microsoft/spring/data/gremlin/annotation/Vertex.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.spring.data.gremlin.annotation;
+
+import com.microsoft.spring.data.gremlin.common.Constants;
+import org.springframework.data.annotation.Persistent;
+
+import java.lang.annotation.*;
+
+/**
+ * Specifies the class as vertex in graph, with one optional label(String).
+ * @author Incarnation-p-lee
+ */
+@Persistent
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Vertex {
+    /**
+     * The label(gremlin reserved) of given Vertex, can add Vertex by label.
+     * @return class name if not specify.
+     */
+    String label() default Constants.DEFAULT_VERTEX_LABEL;
+}

--- a/src/main/java/com/microsoft/spring/data/gremlin/common/Constants.java
+++ b/src/main/java/com/microsoft/spring/data/gremlin/common/Constants.java
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.spring.data.gremlin.common;
+
+public class Constants {
+    private Constants() {
+        // Hide default constructor
+    }
+
+    public static final String DEFAULT_VERTEX_LABEL = "";
+}


### PR DESCRIPTION
* Annotation @Vertex is for domain class, indicates one Vertex in graph.

* It has one optional label field, will return short name of class by default.

* Create one Class integrate Constants variables.

Signed-off-by: Pan Li <panli@microsoft.com>